### PR TITLE
arreglar sidebar y navbar

### DIFF
--- a/resources/css/7-components/_dashboard-menu-admin.scss
+++ b/resources/css/7-components/_dashboard-menu-admin.scss
@@ -18,7 +18,7 @@
     background-color: #FFF;
     transition: left 0.3s ease;
     padding: 1rem;
-    z-index: 999;
+    z-index: 10001;
 }
 
 .dashboard-menu-admin__img{
@@ -83,6 +83,8 @@
         display: flex;
         flex-direction: column;
         padding: 0;
+        top: 60px;
+        height: calc(100vh - 60px);
     }
 
     // ul

--- a/resources/css/7-components/_user-bar-admin.scss
+++ b/resources/css/7-components/_user-bar-admin.scss
@@ -6,7 +6,9 @@
     font-size: rem(13px);
     height: 60px;
     justify-content: space-between;
-    position: relative;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
 }
 
 .user-bar-admin__profile {
@@ -267,6 +269,8 @@
 @media (min-width: 768px) and (max-width: 1080px){
     .user-bar-admin{
         z-index: 1000;
+        position: fixed;
+        width: 100%;
     }
 
     .user-bar-admin__btn-text-large{
@@ -300,6 +304,8 @@
 
     .user-bar-admin{
         z-index: 1000;
+        position: fixed;
+        width: 100%;
     }
 
     .user-bar-admin__btn-icon {

--- a/resources/css/7-components/admin.scss
+++ b/resources/css/7-components/admin.scss
@@ -7,6 +7,7 @@
 .admin-main {
     display: flex;
     flex: 1;
+    margin-top: 60px;
 }
 
 .admin-main__content {
@@ -17,6 +18,6 @@
 
 @media (min-width: 768px){
     .admin-main {
-        
+        margin-top: 60px;
     }
 }

--- a/resources/js/admin/components/unidades/Detalles.vue
+++ b/resources/js/admin/components/unidades/Detalles.vue
@@ -11,7 +11,7 @@
                 <p>No hay programas disponibles para esta preparatoria.</p>
             </div>
             <div v-for="carrera in preparatoriasActivas" :key="carrera.cve_carrera" class="programs__cards db-panel">
-                <p class="cards__carrera">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver más"></span></p>
+                <p class="cards__carrera" @click="verPrograma(carrera.cve_carrera)">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver más"></span></p>
                 <p class="cards__anio">{{ carrera.anio }}</p>
                 <button class="btn btn--db-index btn-card" @click="verPrograma(carrera.cve_carrera)">Ver</button>
             </div>
@@ -21,7 +21,7 @@
                 <p>No hay programas inactivos para esta preparatoria.</p>
             </div>
             <div v-for="carrera in preparatoriasInactivas" :key="carrera.cve_carrera" class="programs__cards db-panel">
-                <p class="cards__carrera">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver más"></span></p>
+                <p class="cards__carrera" @click="verPrograma(carrera.cve_carrera)">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver más"></span></p>
                 <p class="cards__anio">{{ carrera.anio }}</p>
                 <button class="btn btn--db-index btn-card" @click="verPrograma(carrera.cve_carrera)">Ver</button>
             </div>
@@ -40,7 +40,7 @@
                             <p>No hay programas activos de Licenciatura.</p>
                         </div>
                         <div class="programs__cards db-panel" v-for="carrera in licenciaturasActivas" :key="carrera.cve_carrera">
-                            <p class="cards__carrera">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
+                            <p class="cards__carrera" @click="verPrograma(carrera.cve_carrera)">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
                             <p class="cards__anio">{{ carrera.anio }}</p>
                             <button class="btn btn--db-index btn-card" @click="verPrograma(carrera.cve_carrera)">Ver</button>
                         </div>
@@ -53,7 +53,7 @@
                             <p>No hay programas activos de Maestría.</p>
                         </div>
                         <div class="programs__cards db-panel" v-for="carrera in maestriasActivas" :key="carrera.cve_carrera">
-                            <p class="cards__carrera">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
+                            <p class="cards__carrera" @click="verPrograma(carrera.cve_carrera)">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
                             <p class="cards__anio">{{ carrera.anio }}</p>
                             <button class="btn btn--db-index btn-card" @click="verPrograma(carrera.cve_carrera)">Ver</button>
                         </div>
@@ -66,7 +66,7 @@
                             <p>No hay programas activos de Doctorado.</p>
                         </div>
                         <div class="programs__cards db-panel" v-for="carrera in doctoradosActivas" :key="carrera.cve_carrera">
-                            <p class="cards__carrera">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
+                            <p class="cards__carrera" @click="verPrograma(carrera.cve_carrera)">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
                             <p class="cards__anio">{{ carrera.anio }}</p>
                             <button class="btn btn--db-index btn-card" @click="verPrograma(carrera.cve_carrera)">Ver</button>
                         </div>
@@ -85,7 +85,7 @@
                             <p>No hay programas inactivos de Licenciatura.</p>
                         </div>
                         <div class="programs__cards db-panel" v-for="carrera in licenciaturasInactivas" :key="carrera.cve_carrera">
-                            <p class="cards__carrera">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
+                            <p class="cards__carrera" @click="verPrograma(carrera.cve_carrera)">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
                             <p class="cards__anio">{{ carrera.anio }}</p>
                             <button class="btn btn--db-index btn-card" @click="verPrograma(carrera.cve_carrera)">Ver</button>
                         </div>
@@ -98,7 +98,7 @@
                             <p>No hay programas inactivos de Maestría.</p>
                         </div>
                         <div class="programs__cards db-panel" v-for="carrera in maestriasInactivas" :key="carrera.cve_carrera">
-                            <p class="cards__carrera">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
+                            <p class="cards__carrera" @click="verPrograma(carrera.cve_carrera)">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
                             <p class="cards__anio">{{ carrera.anio }}</p>
                             <button class="btn btn--db-index btn-card" @click="verPrograma(carrera.cve_carrera)">Ver</button>
                         </div>
@@ -111,7 +111,7 @@
                             <p>No hay programas inactivos de Doctorado.</p>
                         </div>
                         <div class="programs__cards db-panel" v-for="carrera in doctoradosInactivas" :key="carrera.cve_carrera">
-                            <p class="cards__carrera">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
+                            <p class="cards__carrera" @click="verPrograma(carrera.cve_carrera)">{{ carrera.desc_carrera }} <span><img src="/static/img/Vector.png" alt="ver mas"></span></p>
                             <p class="cards__anio">{{ carrera.anio }}</p>
                             <button class="btn btn--db-index btn-card" @click="verPrograma(carrera.cve_carrera)">Ver</button>
                         </div>


### PR DESCRIPTION
Arregle el sidebar y el navbar para que se queden en un sola posición, también no había puesto para que en dispositivos pequeños me mostraran los programas de las carreras que se elijan, ya que quite el botón de ver en dispositivos pequeños

Cuando le daba scroll el navbar se quedaba arriba y se tenía que regresar si quisiera cambiar del menú o cerrar sesión
![image](https://github.com/user-attachments/assets/cdf72af7-cab8-471b-8c18-fd7ca9333a58)

Pasaba lo mismo en dispositivos grandes
![image](https://github.com/user-attachments/assets/c8cdeebf-2efb-4ab4-a5ce-309ef130a91a)

