### PR TITLE
mostrar grupos por ciclo

### DIFF
--- a/administracion/models.py
+++ b/administracion/models.py
@@ -166,3 +166,19 @@ class Materias_cadenas(models.Model):
 		db_table 		= '"DESARROLLO"."CADENA"'
 		app_label 		= 'desarrollo'
 		verbose_name_plural = "Materias_cadenas"
+
+class Ciclos(models.Model):
+	cve_ciclo 				= models.PositiveSmallIntegerField(primary_key=True)
+	f_inicial 				= models.DateField()
+	f_final 				= models.DateField()
+	cve_tipo_ciclo 			= models.PositiveSmallIntegerField()
+	desc_ciclo 				= models.CharField(max_length=16)
+	admision				= models.CharField(max_length=1)
+	actual_adm				= models.CharField(max_length=1)
+	cve_tipo_ciclo			= models.IntegerField()
+	actual_ni				= models.CharField(max_length=1)
+
+	class Meta:
+		managed 	= False
+		db_table 	= 'CICLO'
+		app_label 	= 'desarrollo'

--- a/administracion/urls.py
+++ b/administracion/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
 	path('carreras/<str:cve_escuela>/', unidad.carreras, name="carreras"),
 	path('materias_plan/', unidad.materias_plan_actual, name="materias_plan"),
 	path('materia-info/', unidad.info_materias, name="materia-info"),
+    path('grupos-ciclos/<int:cve_ciclo>/<str:cve_carrera>/<str:cve_materia>/<str:cve_plan>', unidad.grupos_por_ciclo, name='grupos_por_ciclo'),
 
 	path('profesor/', profesor.index, name='profesor' ),
 	path('profesor/info/', profesor.infoProfesor, name='profesor_info'),

--- a/administracion/views/unidad.py
+++ b/administracion/views/unidad.py
@@ -179,8 +179,6 @@ def grupos_por_ciclo(request, cve_ciclo, cve_carrera, cve_materia, cve_plan):
             'cupo': grupo.cupo,
             'inscritos': inscritos_dict.get(grupo.cve_grupo, 0),
         })
-
-    print(grupos_info)
     
     return JsonResponse({ 'grupos': grupos_info }, safe=False)
 
@@ -197,8 +195,6 @@ def ciclos_anteriores():
     ciclos_filtrados = [c for c in ciclos if c.cve_ciclo % 5 == 0][:4]
 
     ciclos_json = [{'cve_ciclo': c.cve_ciclo, 'desc_ciclo': c.desc_ciclo} for c in ciclos_filtrados]
-
-    print("Ciclos obtenidos desde la base de datos:", ciclos_json)
 
     return ciclos_json
     #return render(request, "admin/unidad/programa.html", {'ciclos': ciclos_json})

--- a/resources/js/admin/components/unidades/Modal.vue
+++ b/resources/js/admin/components/unidades/Modal.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="modal modal-overlay" @click="handleClose">
+    <div class="modal modal-overlay">
       <div class="base-modal__panel modal-groups__card">
         <div class="modal-groups__close-button">
             <button  @click="handleClose"><img src="/static/img/Icon x.png" alt="Icono cerrar"></button>
@@ -22,13 +22,14 @@
             <hr>
             <div class="base-modal__container-grupos">
                 <div class="grupos-select">
-                    <select class="select-field form-field">
-                        <option disabled selected>Semestre 2025-A</option>
+                    <select v-model="selectedCiclo" class="select-field form-field" @change="obtenerGruposPorCiclo">
+                        <option value="" disabled selected>-- Ciclos anteriores --</option>
+                        <option v-for="ciclo in info.ciclos" :key="ciclo.cve_ciclo" :value="ciclo.cve_ciclo">{{ ciclo.desc_ciclo }}</option>
                     </select>
                 </div>
                 <p><span>Grupos asignados: </span>{{ gruposAsignados }} de {{ totalGrupos }}</p>
                 <div class="grupos">
-                    <div class="grupos__info" v-for="(grupo, index) in info.grupos" :key="index">
+                    <div class="grupos__info" v-for="(grupo, index) in gruposMostrar" :key="index">
                         <div class="grupos__info--header">
                             <div><h1 class="grupos__title">Grupo {{ grupo.grupo }}</h1></div>
                             <div class="grupos__cupo">
@@ -70,7 +71,18 @@
         
       info: {
         type: Object
+      },
+      ciclos: {
+        type: Array,
+        required: true 
       }
+    },
+
+    data(){
+        return{
+            selectedCiclo: "",
+            grupos: [],
+        }
     },
 
     computed: {
@@ -79,7 +91,10 @@
         },
         totalGrupos() {
             return this.info.grupos?.length || 0;
-        }
+        },
+        gruposMostrar() {
+            return this.grupos.length > 0 ? this.grupos : this.info.grupos || [];
+        },
     },
   
     methods: {
@@ -91,9 +106,24 @@
       },
 
       handleClose() {
-        if (event.target.closest(".base-modal__panel")) return;
         this.$emit('close');
-      }
+      },
+
+      obtenerGruposPorCiclo() {
+        if(this.selectedCiclo){
+                axios.get(`/admi/grupos-ciclos/${this.selectedCiclo}/${this.cve_carrera}/${this.info.info_materia[0].clave}/${this.cve_plan}`)
+                .then(response => {
+                    console.log("Grupos recibidos:", response.data);
+
+                    this.grupos = Array.isArray(response.data.grupos) ? response.data.grupos : [];
+
+                    console.log("Grupos asignados a this.grupos:", this.grupos);
+                })
+                .catch(error => {
+                    console.error("Error al obtener los grupos:", error);
+                });
+            }
+        }
     }
   };
 </script>

--- a/resources/js/admin/components/unidades/Programa.vue
+++ b/resources/js/admin/components/unidades/Programa.vue
@@ -6,6 +6,7 @@
         <div v-if="planes_actuales.length > 0">
             <div class="section">
                 <div class="container plan-container">
+                    {{ ciclos }}
                     <div>
                         <select v-model="planSeleccionado" class="select-field form-field">
                             <option disabled value="">-- Selecciona un plan --</option>
@@ -33,7 +34,7 @@
                 </div>
             </div>
 
-            <modal v-if="modalVisible" :materia="materiaSeleccionada" :cve_carrera="cve_carrera" :cve_plan="planSeleccionado" :info="materia_info" @close="cerrarModal" />
+            <modal v-if="modalVisible" :ciclos="ciclos" :materia="materiaSeleccionada" :cve_carrera="cve_carrera" :cve_plan="planSeleccionado" :info="materia_info" @close="cerrarModal" />
         </div>
         <div v-else class="section">
             <div class="container"><p>Sin planes activos</p></div>
@@ -63,6 +64,11 @@
             planes_actuales:{
                 type: [String, Number],
                 required: true
+            },
+
+            ciclos: {
+                type: [String, Number],
+                required: true 
             },
         },
 
@@ -130,6 +136,7 @@
 
         mounted() {
             this.carreraNombre = localStorage.getItem('carrera_nombre') || 'Nombre no disponible';
+            console.log("ciclos: " + this.ciclos);
             
         }
     }


### PR DESCRIPTION
Agregue varios ciclos pasados en el select para que se puedan ver los grupos anteriores, así viene en el diseño pero no se si se ocupe, por defecto ya trae los grupos del ciclo actual.

![image](https://github.com/user-attachments/assets/86eb3a23-7d49-4f3a-8fe2-9a26f91dee83)
![image](https://github.com/user-attachments/assets/6b105ea6-b5a5-4442-84fa-6c70248f2fe8)
![image](https://github.com/user-attachments/assets/7b5dea29-aafc-4948-85ca-4a9091bbb637)
